### PR TITLE
Update Upstream (Paper)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ version = 1.17.1-R0.1-SNAPSHOT
 
 mcVersion = 1.17.1
 packageVersion = 1_17_R1
-paperCommit = aad7d376a87f62538420f0dc706aeee202aed814
+paperCommit = 1707c10395e9dba7fd24d7bdf3d625b6b115ae44
 
 org.gradle.jvmargs=-Xmx3G
 


### PR DESCRIPTION
[6084ac3](https://github.com/PaperMC/Paper/commit/6084ac368f577f6534f1c9340fd99738663be062) - Fix upstream nullability on entity equipment getters
[655cd8f](https://github.com/PaperMC/Paper/commit/655cd8f6386ad236bb3111374004b7b593fb065b) - Fix upstreams fix for composters and variable hoppers
[7ac51f9](https://github.com/PaperMC/Paper/commit/7ac51f9c15afc541cdba4c109845692686dfcc67) - Include slot when constructing the bukkit Attribute Modifiers
[caa4780](https://github.com/PaperMC/Paper/commit/caa4780282c5f5003b04cee03d8d7fa74eb54f8e) - Add more component name methods
[9460497](https://github.com/PaperMC/Paper/commit/9460497d71bc53aaf5208d86d128096fd8d3ec32) - Apply furnace cook speed multiplier through event
[f4f5a76](https://github.com/PaperMC/Paper/commit/f4f5a76e2a47312c8b16827b709fe28bcde06161) - Fix anvil inventory events
[1707c10](https://github.com/PaperMC/Paper/commit/1707c10395e9dba7fd24d7bdf3d625b6b115ae44) - fixes cancelling PlayerTradeEvent